### PR TITLE
Read 2 bytes for SSN

### DIFF
--- a/Direct Syscalls/injection.c
+++ b/Direct Syscalls/injection.c
@@ -32,7 +32,11 @@ VOID GetSyscallNumber(
         return;
     }
 
-    *NtFunctionSSN = ((PBYTE)(NtFunctionAddress + 0x4))[0];
+    // Read the 4th and 5th bytes, as the system call numbers occupy 2 bytes
+    BYTE byte4 = ((PBYTE)NtFunctionAddress)[4];
+    BYTE byte5 = ((PBYTE)NtFunctionAddress)[5];
+    *NtFunctionSSN = (byte5 << 8) | byte4; // Combine to a single DWORD
+    
     INFO("[0x%p] [0x%0.3lx] -> %s", (PVOID)NtFunctionAddress, *NtFunctionSSN, NtFunctionName);
     return;
 

--- a/Indirect Syscalls/injection.c
+++ b/Indirect Syscalls/injection.c
@@ -35,7 +35,11 @@ VOID IndirectPrelude(
         return;
     }
 
-    *NtFunctionSSN = ((PBYTE)(NtFunctionAddress + 0x4))[0];
+    // Read the 4th and 5th bytes, as the system call numbers occupy 2 bytes
+    BYTE byte4 = ((PBYTE)NtFunctionAddress)[4];
+    BYTE byte5 = ((PBYTE)NtFunctionAddress)[5];
+    *NtFunctionSSN = (byte5 << 8) | byte4; // Combine to a single DWORD
+
     *NtFunctionSyscall = NtFunctionAddress + 0x12;
 
     /* making memcmp happy */


### PR DESCRIPTION
Correctly reads 2 bytes instead of 1 byte from the SSN - previously, if the SSN was larger than 255 the incorrect SSN would be read, leading to an exception at runtime.